### PR TITLE
Add defaults for LlrfGen2 target

### DIFF
--- a/firmware/targets/LlrfGen2/config/defaults.yaml
+++ b/firmware/targets/LlrfGen2/config/defaults.yaml
@@ -1,0 +1,1362 @@
+- AmcCarrierCore:
+    - SwRssiServer:
+        - MaxOutOfSeq: !<value> 0x00
+        - MaxCumAck: !<value> 0x03
+        - MaxNumRetrans: !<value> 0x02
+        - NullSegTimeout: !<value> 0x00c8
+        - CumAckTimeout: !<value> 0x0019
+        - RetransTimeout: !<value> 0x0032
+        - MaxSegSize: !<value> 0x0400
+        - MaxOutsSeg: !<value> 0x08
+        - Version: !<value> 0x1
+        - InitSeqN: !<value> 0x80
+        - InjectFault: !<value> 0x0
+        - Mode: !<value> 0x0
+        - CloseConn: !<value> 0x0
+        - OpenConn: !<value> 0x0
+        - HeaderChksumEn: !<value> 0x1
+    - BpUdpClient:
+        - ClientRemoteIp: !<value> 0x00000000
+        - ClientRemotePort: !<value> 0x0000
+    - AmcCarrierBsa:
+        - BsaWaveformEngine:
+            - WaveformEngineBuffers:
+                - FramesAfterTrigger: !<value> 0x0000
+                - MsgDest: !<value>
+                    - Auto-Readout
+                    - Auto-Readout
+                    - Software
+                    - Auto-Readout
+                    - Auto-Readout
+                    - Auto-Readout
+                    - Auto-Readout
+                    - Auto-Readout
+                - SoftTrigger: !<value> 0x0
+                - Init: !<value> 0x0
+                - Mode: !<value>
+                    - DoneWhenFull
+                    - DoneWhenFull
+                    - Wrap
+                    - DoneWhenFull
+                    - DoneWhenFull
+                    - DoneWhenFull
+                    - DoneWhenFull
+                    - DoneWhenFull
+                - Enabled: !<value> 0x1
+                - EndAddr: !<value>
+                    - 0x000000000fffffff
+                    - 0x000000001fffffff
+                    - 0x000000002fffffff
+                    - 0x000000003fffffff
+                    - 0x000000004fffffff
+                    - 0x000000005fffffff
+                    - 0x000000006fffffff
+                    - 0x000000007fffffff
+                - StartAddr: !<value>
+                    - 0x0000000000000000
+                    - 0x0000000010000000
+                    - 0x0000000020000000
+                    - 0x0000000030000000
+                    - 0x0000000040000000
+                    - 0x0000000050000000
+                    - 0x0000000060000000
+                    - 0x0000000070000000
+    - RssiServerInterleaved:
+        - MaxOutOfSeq: !<value> 0x00
+        - MaxCumAck: !<value> 0x00
+        - MaxNumRetrans: !<value> 0x00
+        - NullSegTimeout: !<value> 0x0000
+        - CumAckTimeout: !<value> 0x0000
+        - RetransTimeout: !<value> 0x0000
+        - MaxSegSize: !<value> 0x0000
+        - MaxOutsSeg: !<value> 0x00
+        - Version: !<value> 0x0
+        - InitSeqN: !<value> 0x00
+        - InjectFault: !<value> 0x0
+        - Mode: !<value> 0x0
+        - CloseConn: !<value> 0x0
+        - OpenConn: !<value> 0x0
+        - HeaderChksumEn: !<value> 0x0
+    - AxiSy56040:
+        - OutputConfig: !<value>
+            - RTM_TIMING_IN0
+            - RTM_TIMING_IN0
+            - RTM_TIMING_IN1
+            - RTM_TIMING_IN1
+    - AmcCarrierTiming:
+        - GthRxAlignCheck:
+            - ResetLen: !<value> 0x3
+            - PhaseMask: !<value> 0x7e
+            - PhaseTarget: !<value> 0x10
+        - EvrV2CoreTriggers:
+            - EvrV2TriggerReg:
+                - DelayTap: !<value> 0x00
+                - Width: !<value>
+                    - 0x0000001
+                    - 0x0000001
+                    - 0x0000001
+                    - 0x0000001
+                    - 0x0000001
+                    - 0x0000001
+                    - 0x0000001
+                    - 0x0000001
+                    - 0x0000000
+                    - 0x0000000
+                    - 0x0000000
+                    - 0x0000000
+                    - 0x0000000
+                    - 0x0000000
+                    - 0x0000000
+                    - 0x0000000
+                - Delay: !<value> 0x0000000
+                - Polarity: !<value>
+                    - Rising
+                    - Rising
+                    - Rising
+                    - Rising
+                    - Rising
+                    - Rising
+                    - Rising
+                    - Rising
+                    - Falling
+                    - Falling
+                    - Falling
+                    - Falling
+                    - Falling
+                    - Falling
+                    - Falling
+                    - Falling
+                - Source: !<value>
+                    - 0x0
+                    - 0x1
+                    - 0x2
+                    - 0x3
+                    - 0x4
+                    - 0x5
+                    - 0x6
+                    - 0x7
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                - Enable: !<value>
+                    - 0x0
+                    - 0x1
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+            - EvrV2ChannelReg:
+                - BsaWindowWidth: !<value> 0x00000
+                - BsaWindowSetup: !<value> 0x00
+                - BsaWindowDelay: !<value> 0x00000
+                - DestSel: !<value>
+                    - 0x20000
+                    - 0x20000
+                    - 0x20000
+                    - 0x20000
+                    - 0x20000
+                    - 0x20000
+                    - 0x20000
+                    - 0x20000
+                    - 0x00000
+                    - 0x00000
+                    - 0x00000
+                    - 0x00000
+                    - 0x00000
+                    - 0x00000
+                    - 0x00000
+                    - 0x00000
+                - BsaEnabled: !<value> 0x0
+                - DmaEnabled: !<value> 0x0
+                - Enable: !<value>
+                    - 0x1
+                    - 0x1
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                    - 0x0
+                - RateSel: !<value>
+                    - 0x1029
+                    - 0x1029
+                    - 0x1000
+                    - 0x1000
+                    - 0x1000
+                    - 0x1000
+                    - 0x1000
+                    - 0x1000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+        - TimingFrameRx:
+            - MsgDelay: !<value> 0x04e20
+            - MsgDelayRst: !<value> 0x0
+            - MsgNoDelay: !<value> 0x0
+            - BypassRst: !<value> 0x0
+            - RxDown: !<value> 0x1
+            - ClkSel: !<value> 0x0
+            - RxReset: !<value> 0x0
+            - RxPolarity: !<value> 0x0
+            - RxCountReset: !<value> 0x0
+        - Gthe3Channel:
+            - ES_ERRDET_EN: !<value> 0x0
+            - ES_CONTROL: !<value> 0x00
+            - TX_PROGDIV_CFG: !<value> 0x8000
+            - RXDFE_HC_CFG0: !<value> 0x0000
+            - ES_QUALIFIER: !<value> 0x0000
+            - ES_QUAL_MASK: !<value> 0x0000
+            - ES_SDATA_MASK: !<value> 0x0000
+            - FTS_DESKEW_SEQ_ENABLE: !<value> 0xf
+            - FTS_LANE_DESKEW_EN: !<value> 0x0
+            - ES_HORZ_OFFSET: !<value> 0x000
+            - FTS_LANE_DESKEW_CFG: !<value> 0x0
+            - RXDFE_HC_CFG1: !<value> 0x0000
+            - ES_PMA_CFG: !<value> 0x000
+            - RX_DFE_AGC_CFG0: !<value> 0x2
+            - RX_EN_HI_LR: !<value> 0x0
+            - RX_DFE_AGC_CFG1: !<value> 0x0
+            - RXDFE_CFG: !<value>
+                - 0x0a00
+                - 0x0000
+            - ALIGN_MCOMMA_VALUE: !<value> 0x283
+            - ALIGN_MCOMMA_DET: !<value> 0x1
+            - PCS_PCIE_EN: !<value> 0x0
+            - LOCAL_MASTER: !<value> 0x1
+            - ALIGN_PCOMMA_VALUE: !<value> 0x17c
+            - RXDFE_OS_CFG0: !<value> 0x8000
+            - ALIGN_PCOMMA_DET: !<value> 0x1
+            - TXDLY_LCFG: !<value> 0x0050
+            - RXPHDLY_CFG: !<value> 0x2020
+            - RXDFE_OS_CFG1: !<value> 0x0000
+            - RXDLY_CFG: !<value> 0x001f
+            - RXDLY_LCFG: !<value> 0x0030
+            - RXDFE_HF_CFG0: !<value> 0x0000
+            - RXDFE_HD_CFG0: !<value> 0x0000
+            - RX_BIAS_CFG0: !<value> 0x0ab4
+            - PCS_RSVD0: !<value> 0x0000
+            - RX_CM_SEL: !<value> 0x3
+            - RX_CM_TRIM: !<value> 0xa
+            - RX_CM_BUF_CFG: !<value> 0xa
+            - RX_CM_BUF_PD: !<value> 0x0
+            - RX_SUM_VREF_TUNE: !<value> 0x0
+            - RX_SUM_VCMTUNE: !<value> 0x0
+            - RXPH_MONITOR_SEL: !<value> 0x00
+            - RX_SUM_RES_CTRL: !<value> 0x3
+            - RX_SUM_IREF_TUNE: !<value> 0xc
+            - RX_SUM_VCM_OVWR: !<value> 0x0
+            - RX_SUM_DFETAPREP_EN: !<value> 0x0
+            - RXOUT_DIV: !<value> 0x1
+            - RXOOB_CFG: !<value> 0x006
+            - OOB_PWRUP: !<value> 0x0
+            - CBCC_DATA_SOURCE_SEL: !<value> 0x1
+            - RXGEARBOX_EN: !<value> 0x0
+            - RX_XCLK_SEL: !<value> 0x1
+            - RXBUF_EN: !<value> 0x0
+            - RXPRBS_ERR_LOOPBACK: !<value> 0x0
+            - RXSLIDE_MODE: !<value> 0x0
+            - RXBUF_THRESH_OVFLW: !<value> 0x00
+            - RXSLIDE_AUTO_WAIT: !<value> 0x7
+            - DMONITOR_CFG0: !<value> 0x000
+            - RX_SIG_VALID_DLY: !<value> 0x0a
+            - RX_INT_DATAWIDTH: !<value> 0x0
+            - RX_WIDEMODE_CDR: !<value> 0x0
+            - RXBUF_ADDR_MODE: !<value> 0x1
+            - RX_DISPERR_SEQ_MATCH: !<value> 0x1
+            - RX_CLKMUX_EN: !<value> 0x1
+            - RXBUF_THRESH_UNDFLW: !<value> 0x00
+            - RXBUF_RESET_ON_CB_CHANGE: !<value> 0x1
+            - RXBUF_RESET_ON_RATE_CHANGE: !<value> 0x1
+            - RXCDR_PH_RESET_ON_EIDLE: !<value> 0x0
+            - RXBUF_THRESH_OVRD: !<value> 0x0
+            - RXBUF_RESET_ON_COMMAALIGN: !<value> 0x0
+            - RXCDR_FR_RESET_ON_EIDLE: !<value> 0x0
+            - RXBUF_RESET_ON_EIDLE: !<value> 0x0
+            - RXBUF_EIDLE_LO_CNT: !<value> 0x0
+            - RX_DFE_LPM_HOLD_DURING_EIDLE: !<value> 0x0
+            - RXCDR_HOLD_DURING_EIDLE: !<value> 0x0
+            - RXBUF_EIDLE_HI_CNT: !<value> 0x8
+            - SATA_EIDLE_VAL: !<value> 0x0
+            - SATA_BURST_VAL: !<value> 0x4
+            - SAS_MIN_COM: !<value> 0x24
+            - SATA_BURST_SEQ_LEN: !<value> 0xe
+            - SATA_MIN_BURST: !<value> 0x04
+            - SATA_MIN_WAKE: !<value> 0x04
+            - SAS_MAX_COM: !<value> 0x20
+            - SATA_MIN_INIT: !<value> 0x0c
+            - SATA_MAX_BURST: !<value> 0x08
+            - SATA_MAX_WAKE: !<value> 0x07
+            - RX_CLK25_DIV: !<value> 0x0e
+            - SATA_MAX_INIT: !<value> 0x15
+            - TXPHDLY_CFG: !<value>
+                - 0x2020
+                - 0x0075
+            - TXDLY_CFG: !<value> 0x0009
+            - TAPDLY_SET_TX: !<value> 0x0
+            - TXPH_MONITOR_SEL: !<value> 0x00
+            - RXCDR_LOCK_CFG2: !<value> 0x77c3
+            - TXPH_CFG: !<value> 0x0980
+            - TERM_RCAL_CFG: !<value> 0x4210
+            - PD_TRANS_TIME_FROM_P2: !<value> 0x03c
+            - TERM_RCAL_OVRD: !<value> 0x0
+            - RXDFE_HF_CFG1: !<value> 0x0000
+            - PD_TRANS_TIME_TO_P2: !<value> 0x64
+            - PD_TRANS_TIME_NONE_P2: !<value> 0x19
+            - TRANS_TIME_RATE: !<value> 0x0e
+            - TST_RSV1: !<value> 0x00
+            - TST_RSV0: !<value> 0x00
+            - TX_DATA_WIDTH: !<value> 0x3
+            - TX_XCLK_SEL: !<value> 0x1
+            - TX_CLK25_DIV: !<value> 0x0e
+            - TX_DEEMPH0: !<value> 0x00
+            - TX_DEEMPH1: !<value> 0x00
+            - TXFIFO_ADDR_CFG: !<value> 0x0
+            - TX_RXDETECT_REF: !<value> 0x4
+            - TXBUF_RESET_ON_RATE_CHANGE: !<value> 0x1
+            - TXBUF_EN: !<value> 0x0
+            - TXOUT_DIV: !<value> 0x1
+            - TXGEARBOX_EN: !<value> 0x0
+            - TX_MAINCURSOR_SEL: !<value> 0x0
+            - TX_RXDETECT_CFG: !<value> 0x0032
+            - TX_EIDLE_DEASSERT_DELAY: !<value> 0x3
+            - TX_EIDLE_ASSERT_DELAY: !<value> 0x4
+            - TX_DRIVE_MODE: !<value> 0x00
+            - TX_LOOPBACK_DRIVE_HIZ: !<value> 0x0
+            - TX_CLKMUX_EN: !<value> 0x1
+            - TX_MARGIN_FULL_1: !<value> 0x4e
+            - TX_MARGIN_FULL_0: !<value> 0x4f
+            - TX_MARGIN_LOW_0: !<value> 0x46
+            - TX_MARGIN_FULL_2: !<value> 0x4c
+            - TX_MARGIN_FULL_3: !<value> 0x4a
+            - TX_MARGIN_FULL_4: !<value> 0x48
+            - TX_MARGIN_LOW_2: !<value> 0x43
+            - TX_MARGIN_LOW_1: !<value> 0x45
+            - TX_MARGIN_LOW_4: !<value> 0x40
+            - TX_MARGIN_LOW_3: !<value> 0x42
+            - RXDFE_HD_CFG1: !<value> 0x0000
+            - TX_INT_DATAWIDTH: !<value> 0x0
+            - TX_QPI_STATUS_EN: !<value> 0x0
+            - RXPRBS_LINKACQ_CNT: !<value> 0x0f
+            - RXOSCALRESET_TIME: !<value> 0x03
+            - TXSYNC_SKIP_DA: !<value> 0x0
+            - RXOOB_CLK_CFG: !<value> 0x0
+            - RXSYNC_SKIP_DA: !<value> 0x0
+            - A_RXOSCALRESET: !<value> 0x0
+            - TX_IDLE_DATA_ZERO: !<value> 0x0
+            - RXSYNC_OVRD: !<value> 0x0
+            - TX_PMADATA_OPT: !<value> 0x0
+            - TXSYNC_OVRD: !<value> 0x0
+            - RX_CTLE3_LPF: !<value> 0x01
+            - RXSYNC_MULTILANE: !<value> 0x0
+            - TXSYNC_MULTILANE: !<value> 0x0
+            - RX_DFE_KL_LPM_KL_CFG1: !<value> 0x0
+            - RX_DFE_KL_LPM_KL_CFG0: !<value> 0x1
+            - RX_TUNE_AFE_OS: !<value> 0x2
+            - RESET_POWERSAVE_DISABLE: !<value> 0x0
+            - ACJTAG_RESET: !<value> 0x0
+            - ACJTAG_DEBUG_MODE: !<value> 0x0
+            - RXDFE_VP_CFG0: !<value> 0xaa00
+            - ACJTAG_MODE: !<value> 0x0
+            - RXDFE_UT_CFG1: !<value> 0x0003
+            - RXDFE_VP_CFG1: !<value> 0x0033
+            - RXCFOK_CFG0: !<value> 0x4000
+            - ADAPT_CFG1: !<value> 0x0000
+            - ADAPT_CFG0: !<value> 0xf800
+            - USE_PCS_CLK_PHASE_SEL: !<value> 0x0
+            - RXDFELPM_KL_CFG2: !<value> 0x0000
+            - ES_CLK_PHASE_SEL: !<value> 0x0
+            - PMA_RSV1: !<value> 0xe000
+            - RX_EYESCAN_VS_RANGE: !<value> 0x0
+            - RX_EYESCAN_VS_CODE: !<value> 0x00
+            - RX_EYESCAN_VS_UT_SIGN: !<value> 0x0
+            - RX_EYESCAN_VS_NEG_DIR: !<value> 0x0
+            - RX_AFE_CM_EN: !<value> 0x0
+            - RXDFE_HE_CFG1: !<value> 0x0000
+            - RX_CAPFF_SARC_ENB: !<value> 0x0
+            - TXPI_VREFSEL: !<value> 0x0
+            - TXPI_LPM: !<value> 0x0
+            - TXPI_GRAY_SEL: !<value> 0x0
+            - TXPI_INVSTROBE_SEL: !<value> 0x0
+            - TXPI_PPMCLK_SEL: !<value> 0x1
+            - TXPI_SYNFREQ_PPM: !<value> 0x1
+            - GEARBOX_MODE: !<value> 0x00
+            - TXPI_PPM_CFG: !<value> 0x00
+            - RX_DFE_KL_LPM_KH_CFG0: !<value> 0x1
+            - RX_DFE_KL_LPM_KH_CFG1: !<value> 0x0
+            - RX_DFELPM_CFG1: !<value> 0x1
+            - TXPI_CFG5: !<value> 0x3
+            - RX_DFELPM_KLKH_AGC_STUP_EN: !<value> 0x1
+            - RX_DFELPM_CFG0: !<value> 0x6
+            - TXPI_CFG4: !<value> 0x1
+            - TXPI_CFG3: !<value> 0x1
+            - TXPI_CFG2: !<value> 0x1
+            - TXPI_CFG1: !<value> 0x1
+            - TXPI_CFG0: !<value> 0x1
+            - RXPI_CFG0: !<value> 0x1
+            - RXPI_CFG6: !<value> 0x3
+            - RXPI_CFG5: !<value> 0x1
+            - RXPI_CFG4: !<value> 0x1
+            - RXPI_CFG3: !<value> 0x1
+            - RXPI_CFG2: !<value> 0x1
+            - RXPI_CFG1: !<value> 0x1
+            - RXDFE_GC_CFG0: !<value> 0x0000
+            - RXDFE_GC_CFG1: !<value> 0x7870
+            - RXDFE_UT_CFG0: !<value> 0x8000
+            - RXDFE_GC_CFG2: !<value> 0x0000
+            - RXCDR_CFG0_GEN3: !<value> 0x0000
+            - RXCDR_CFG2_GEN3: !<value> 0x07e6
+            - RXCDR_CFG3_GEN3: !<value> 0x0000
+            - RXCDR_CFG1_GEN3: !<value> 0x0000
+            - RXCDR_CFG4_GEN3: !<value> 0x0000
+            - RXCDR_CFG5_GEN3: !<value> 0x0000
+            - RXCDR_CFG5: !<value> 0x0000
+            - PCIE_RXPMA_CFG: !<value> 0x000a
+            - PCIE_TXPCS_CFG_GEN3: !<value> 0x2ca4
+            - PCIE_TXPMA_CFG: !<value> 0x000a
+            - RXPI_VREFSEL: !<value> 0x0
+            - PCS_RSVD1: !<value> 0x0
+            - RXPI_LPM: !<value> 0x0
+            - RATE_SW_USE_DRP: !<value> 0x1
+            - RX_CLK_SLIP_OVRD: !<value> 0x00
+            - PLL_SEL_MODE_GEN12: !<value> 0x0
+            - PLL_SEL_MODE_GEN3: !<value> 0x3
+            - RXDFE_H3_CFG0: !<value> 0x4000
+            - EVODD_PHI_CFG: !<value> 0x000
+            - GM_BIAS_SELECT: !<value> 0x0
+            - DFE_VCM_COMP_EN: !<value> 0x0
+            - DFE_D_X_REL_POS: !<value> 0x0
+            - RXDFE_H3_CFG1: !<value> 0x0000
+            - RXDFE_H4_CFG0: !<value> 0x2000
+            - RXDFE_H4_CFG1: !<value> 0x0003
+            - TX_SARC_LPBK_ENB: !<value> 0x0
+            - RXDFE_H5_CFG0: !<value> 0x2000
+            - TX_MODE_SEL: !<value> 0x0
+            - TEMPERATUR_PAR: !<value> 0x2
+            - PROCESS_PAR: !<value> 0x2
+            - RXDFE_H5_CFG1: !<value> 0x0003
+            - CPLL_CFG3: !<value> 0x00
+            - TX_DCD_CFG: !<value> 0x02
+            - TX_DCD_EN: !<value> 0x0
+            - TX_EML_PHI_TUNE: !<value> 0x0
+            - RXDFE_H6_CFG0: !<value> 0x2000
+            - RXDFE_H6_CFG1: !<value> 0x0000
+            - RXDFE_H7_CFG0: !<value> 0x2000
+            - DDI_CTRL: !<value> 0x0
+            - DDI_REALIGN_WAIT: !<value> 0x0f
+            - RX_SAMPLE_PERIOD: !<value> 0x7
+            - RXGBOX_FIFO_INIT_RD_ADDR: !<value> 0x4
+            - TX_SAMPLE_PERIOD: !<value> 0x7
+            - TXGBOX_FIFO_INIT_RD_ADDR: !<value> 0x4
+            - CPLL_CFG2: !<value> 0x0004
+            - RXPHSAMP_CFG: !<value> 0x2100
+            - RXPHSLIP_CFG: !<value> 0x6622
+            - RXPHBEACON_CFG: !<value> 0x0000
+            - RXDFE_H7_CFG1: !<value> 0x0000
+            - RXDFE_H8_CFG0: !<value> 0x2000
+            - RXDFE_H8_CFG1: !<value> 0x0000
+            - PCIE_BUFG_DIV_CTRL: !<value> 0x1000
+            - PCIE_RXPCS_CFG_GEN3: !<value> 0x02a4
+            - RXDFE_H9_CFG1: !<value> 0x0000
+            - RX_PROGDIV_CFG: !<value> 0x8000
+            - RXDFE_H9_CFG0: !<value> 0x2000
+            - RXDFE_HA_CFG0: !<value> 0x2000
+            - CHAN_BOND_SEQ_1_2: !<value> 0x000
+            - CPLL_CFG0: !<value> 0x21f8
+            - CPLL_CFG1: !<value> 0xa4ac
+            - DEC_MCOMMA_DETECT: !<value> 0x1
+            - DEC_VALID_COMMA_ONLY: !<value> 0x0
+            - RX_DDI_SEL: !<value> 0x00
+            - CPLL_INIT_CFG1: !<value> 0x00
+            - RXDFE_HA_CFG1: !<value> 0x0000
+            - ES_EYE_SCAN_EN: !<value> 0x0
+            - RXDFE_HB_CFG0: !<value> 0x2000
+            - RXLPM_GC_CFG: !<value> 0x1000
+            - DMONITOR_CFG1: !<value> 0x00
+            - RXLPM_OS_CFG1: !<value> 0x0002
+            - ES_PRESCALE: !<value> 0x00
+            - RXLPM_OS_CFG0: !<value> 0x8000
+            - RXDFELPM_KL_CFG1: !<value> 0x0032
+            - RXDFELPM_KL_CFG0: !<value> 0x0000
+            - RXLPM_KH_CFG1: !<value> 0x0002
+            - RXLPM_KH_CFG0: !<value> 0x0000
+            - RXLPM_CFG: !<value> 0x0000
+            - RXCFOK_CFG2: !<value> 0x002e
+            - RXDFE_H2_CFG1: !<value> 0x0000
+            - RXDFE_H2_CFG0: !<value> 0x0000
+            - RXCFOK_CFG1: !<value> 0x0065
+            - RXCDR_LOCK_CFG1: !<value> 0x5fff
+            - TX_DIVRESET_TIME: !<value> 0x01
+            - RX_DIVRESET_TIME: !<value> 0x01
+            - DEC_PCOMMA_DETECT: !<value> 0x1
+            - A_TXPROGDIVRESET: !<value> 0x0
+            - A_RXPROGDIVRESET: !<value> 0x0
+            - CPLL_INIT_CFG0: !<value> 0x02b2
+            - CPLL_REFCLK_DIV: !<value> 0x10
+            - CPLL_LOCK_CFG: !<value> 0x01e8
+            - TXDRVBIAS_P: !<value> 0xa
+            - SATA_CPLL_CFG: !<value> 0x0
+            - CPLL_FBDIV: !<value> 0x00
+            - CPLL_FBDIV_45: !<value> 0x1
+            - TXDRVBIAS_N: !<value> 0xa
+            - ALIGN_COMMA_WORD: !<value> 0x2
+            - ALIGN_COMMA_DOUBLE: !<value> 0x0
+            - SHOW_REALIGN_COMMA: !<value> 0x0
+            - RXDFE_HE_CFG0: !<value> 0x0000
+            - CLK_COR_SEQ_2_ENABLE: !<value> 0xf
+            - ALIGN_COMMA_ENABLE: !<value> 0x3ff
+            - CLK_COR_SEQ_2_4: !<value> 0x100
+            - CLK_COR_SEQ_2_3: !<value> 0x100
+            - CLK_CORRECT_USE: !<value> 0x0
+            - CLK_COR_SEQ_2_USE: !<value> 0x0
+            - CLK_COR_SEQ_2_2: !<value> 0x100
+            - CLK_COR_SEQ_1_ENABLE: !<value> 0xf
+            - CLK_COR_SEQ_2_1: !<value> 0x100
+            - CLK_COR_SEQ_1_4: !<value> 0x100
+            - CLK_COR_SEQ_1_3: !<value> 0x100
+            - CLK_COR_SEQ_1_2: !<value> 0x100
+            - CLK_COR_SEQ_1_1: !<value> 0x100
+            - CLK_COR_MAX_LAT: !<value> 0x14
+            - CLK_COR_PRECEDENCE: !<value> 0x1
+            - CLK_COR_REPEAT_WAIT: !<value> 0x00
+            - CLK_COR_SEQ_LEN: !<value> 0x0
+            - CHAN_BOND_KEEP_ALIGN: !<value> 0x0
+            - CLK_COR_KEEP_IDLE: !<value> 0x0
+            - CHAN_BOND_SEQ_2_USE: !<value> 0x0
+            - CHAN_BOND_SEQ_2_ENABLE: !<value> 0xf
+            - CLK_COR_MIN_LAT: !<value> 0x12
+            - CHAN_BOND_SEQ_2_4: !<value> 0x000
+            - CHAN_BOND_SEQ_2_3: !<value> 0x000
+            - CHAN_BOND_SEQ_2_2: !<value> 0x000
+            - CHAN_BOND_SEQ_1_ENABLE: !<value> 0xf
+            - RX_BUFFER_CFG: !<value> 0x00
+            - PCI3_RX_ASYNC_EBUF_BYPASS: !<value> 0x0
+            - CHAN_BOND_SEQ_2_1: !<value> 0x000
+            - RX_DEFER_RESET_BUF_EN: !<value> 0x1
+            - OOBDIVCTL: !<value> 0x0
+            - PCI3_AUTO_REALIGN: !<value> 0x3
+            - PCI3_PIPE_RX_ELECIDLE: !<value> 0x0
+            - PCI3_RX_ELECIDLE_H2L_COUNT: !<value> 0x00
+            - CHAN_BOND_SEQ_1_4: !<value> 0x000
+            - PCI3_RX_ELECIDLE_HI_COUNT: !<value> 0x00
+            - CHAN_BOND_SEQ_1_3: !<value> 0x000
+            - CHAN_BOND_MAX_SKEW: !<value> 0x1
+            - CHAN_BOND_SEQ_LEN: !<value> 0x0
+            - RXCDR_CFG: !<value>
+                - 0x0000
+                - 0x0000
+                - 0x0756
+                - 0x0000
+                - 0x0000
+            - RXCDR_LOCK_CFG0: !<value> 0x4480
+            - CHAN_BOND_SEQ_1_1: !<value> 0x000
+            - TX_PROGCLK_SEL: !<value> 0x1
+            - RXISCANRESET_TIME: !<value> 0x01
+            - WB_MODE: !<value> 0x0
+            - TX_FABINT_USRCLK_FLOP: !<value> 0x0
+            - TXPMARESET_TIME: !<value> 0x03
+            - RXPMACLK_SEL: !<value> 0x0
+            - RX_PMA_POWER_SAVE: !<value> 0x0
+            - TX_PMA_POWER_SAVE: !<value> 0x0
+            - TXPCSRESET_TIME: !<value> 0x03
+            - RXDFE_HB_CFG1: !<value> 0x0000
+            - RXPMARESET_TIME: !<value> 0x03
+            - PCI3_RX_ELECIDLE_LP4_DISABLE: !<value> 0x0
+            - PCI3_RX_ELECIDLE_EI2_ENABLE: !<value> 0x0
+            - RXELECIDLE_CFG: !<value> 0x3
+            - PCI3_RX_FIFO_DISABLE: !<value> 0x0
+            - RXPCSRESET_TIME: !<value> 0x03
+            - RXCDRPHRESET_TIME: !<value> 0x01
+            - PCI3_RX_ELECIDLE_H2L_DISABLE: !<value> 0x0
+            - RX_FABINT_USRCLK_FLOP: !<value> 0x0
+            - RXDFELPMRESET_TIME: !<value> 0x0f
+            - EYE_SCAN_SWAP_EN: !<value> 0x0
+            - RXCDRFREQRESET_TIME: !<value> 0x01
+            - RX_DATA_WIDTH: !<value> 0x3
+            - CDR_SWAP_MODE_EN: !<value> 0x0
+            - RXBUFRESET_TIME: !<value> 0x03
+        - TPGMiniCore:
+            - CountInterval: !<value> 0x0000488b
+            - BsaMaxSeverity: !<value> Invalid
+            - BsaAvgToWr: !<value> 0x0000
+            - BsaNtoAvg: !<value> 0x0000
+            - BsaDestExclusiveMask: !<value> 0xffff
+            - BsaDestMode: !<value> Dont_Care
+            - BsaSequenceBitSelect: !<value> 0x0
+            - BsaDestInclusiveMask: !<value> 0xffff
+            - BsaSequenceSelect: !<value> 0x00
+            - BsaACTSMask: !<value> 0x3f
+            - BsaACRate: !<value> " 60 Hz"
+            - BsaFixedRate: !<value> "  1 MHz"
+            - BsaRateSelMode: !<value> FixedRate
+            - BsaActive: !<value> 0x0
+            - BsaCompleteWr: !<value> 0x0000000000000000
+            - Lcls1BsaStart: !<value> 0x00000000
+            - Lcls1BsaSeverity: !<value> INVALID
+            - Lcls1BsaNumAvgs: !<value> 0x00
+            - Lcls1BsaEdefSlot: !<value> 0x0
+            - Lcls1BsaTimeSlot: !<value> TS1
+            - Lcls1BsaNumSamples: !<value> 0x000
+            - CountIntervalReset: !<value> 0x0
+            - Lcls1BsaRate: !<value> 120Hz
+            - TxReset: !<value> 0x0
+            - RateReload: !<value> 0x0
+            - FixedRateDiv: !<value>
+                - 0x00000001
+                - 0x0000000d
+                - 0x0000005b
+                - 0x0000038e
+                - 0x0000238c
+                - 0x00016378
+                - 0x000de2b0
+                - 0x00000000
+                - 0x00000000
+                - 0x00000000
+            - TStampSet: !<value> 0x0
+            - TStampWr: !<value> 0x000000f50d51105e
+            - PulseIdSet: !<value> 0x0
+            - BaseControl: !<value> 0x0000
+            - TxInhibit: !<value> 0x0
+            - TxLoopback: !<value> 0x0
+            - PulseIdWr: !<value> 0x0000000001cc76a9
+            - TxPolarity: !<value> 0x0
+    - AxiMicronN25Q:
+        - Data: !<value> 0x00000000
+        - Cmd: !<value> 0x000000ff
+        - Addr32BitMode: !<value> 0x0
+        - Test: !<value> 0x00000000
+        - Addr: !<value> 0x00000000
+    - AxiSysMonUltraScale:
+        - AlarmThresholdReg_25_16: !<value>
+            - 0x00009a74
+            - 0x00004da6
+            - 0x00009a74
+            - 0x00004d39
+            - 0x00000000
+            - 0x00000000
+            - 0x00000000
+            - 0x00000000
+        - AlarmThresholdReg16: !<value> 0x00009a74
+        - AlarmThresholdReg12: !<value> 0x00004963
+        - AlarmThresholdReg_8_0: !<value>
+            - 0x0000b723
+            - 0x00004e81
+            - 0x0000a147
+            - 0x0000cb93
+            - 0x0000aa5f
+            - 0x00004963
+            - 0x00009555
+            - 0x0000af7b
+            - 0x00004e81
+        - SequenceReg_7_0: !<value>
+            - 0x00004f01
+            - 0x00000000
+            - 0x00004f00
+            - 0x00000000
+            - 0x00000000
+            - 0x00000000
+            - 0x00000000
+            - 0x00000000
+        - SequenceReg9: !<value> 0x00000000
+        - SequenceRegister8: !<value> 0x00000000
+        - ConfigurationRegister: !<value>
+            - 0x00000000
+            - 0x000021df
+            - 0x00009b00
+            - 0x0000000f
+        - IPIER: !<value> 0x00000000
+        - GIER: !<value> 0x00000000
+        - SYSMONRR: !<value> 0x00000000
+        - CONVSTR: !<value> 0x00000000
+    - AxiVersion:
+        - MasterReset: !<value> 0x0
+        - FpgaReloadAddress: !<value> 0x00000000
+        - FpgaReload: !<value> 0x0
+        - FpgaReloadHalt: !<value> 0x0
+        - ScratchPad: !<value> 0xfc067333
+- AppTop:
+    - DacSigGen:
+        - EnableMask: !<value> 0x3
+        - ModeMask: !<value> 0x0
+        - SignFormat: !<value> 0x0
+        - PeriodSize: !<value> 4095
+        - Waveform[0]:
+            - MemoryArray[0-1023]: !<value> 0x7fff
+            - MemoryArray[1024-4095]: !<value> 0x0
+        - Waveform[1]:
+            - MemoryArray: !<value> 0x0
+    - AppCore:
+        - RtmRfInterlock:
+            - AdcSetDelay: !<value> 0x000
+            - AdcIDelayLoad: !<value> 0x0
+            - AdcFrameSetDelay: !<value> 0x000
+            - SoftBufferClear: !<value> 0x0
+            - DetuneSled: !<value> 0x0
+            - Mode: !<value> 0x0
+            - SoftBufferTrigger: !<value> 0x0
+            - TuneSled: !<value> 0x0
+            - CfgRegister: !<value> 0xff1c
+            - ModNVRegB: !<value> 0x00
+            - ModNVRegA: !<value> 0x00
+            - ModWiperRegA: !<value> 0x2B
+            - ModWiperRegB: !<value> 0x20
+            - KlyWiperRegB: !<value> 0x6C
+            - KlyWiperRegA: !<value> 0x3D
+            - ClearFault: !<value> 0x1 # command to clear fault
+        - BSSS:
+            - EdefDestSel: !<value> 0x00000
+            - EdefRateSel: !<value> 0x0000
+            - EdefEnable: !<value> 0x0
+            - EdefRateLimit: !<value>
+                - Limit_7_Hz
+                - Limit_7_Hz
+                - Limit_7_Hz
+                - Limit_7_Hz
+                - Limit_7_Hz
+                - Limit_7_Hz
+                - Limit_7_Hz
+                - Limit_7_Hz
+                - INVALID_0
+                - INVALID_0
+                - INVALID_0
+                - INVALID_0
+                - INVALID_0
+                - INVALID_0
+                - INVALID_0
+                - INVALID_0
+            - channelSevr: !<value> 0x0000000000000000
+            - channelMask: !<value> 0x00000000
+            - enable: !<value> 0x0
+            - packetSize: !<value> 0x3c0
+        - Sysgen:
+#            - LlrfFeedbackWrapper:
+#                - MODE_CONFIG: !<value> 0x3
+            - LlrfPll:
+                - clockPllKi: !<value> 0x000b6ec9
+                - scratchPad: !<value> 0x00000000
+                - loPllKi: !<value> 0x0000698b
+                - loPllKp: !<value> 0x02dc0b4d
+                - clockPllKp: !<value> 0x4f4bc6a7
+                - clockPllPhaseSet: !<value> 0x0000
+                - loPllPhaseSet: !<value> 0x0000
+                - loDacSet: !<value> 0x0000
+                - loPllPolarity: !<value> 0x0
+                - clockPllPolarity: !<value> 0x0
+                - clockPllReferenceSelect: !<value> 0x0
+                - loPllReferenceSelect: !<value> 0x0
+                - clockDacSet: !<value> 0x0000
+                - userDacControlMux: !<value> 0x0
+                - clockDacControlMux: !<value> 0x0
+                - loDacControlMux: !<value> 0x0
+                - clockPllLockedCounterReset: !<value> 0x0
+                - loPllLockedCounterReset: !<value> 0x0
+                - lossOfLockThreshold: !<value> 0x0666
+                - lossOfSignalThreshold: !<value> 0x2000
+            - LlrfDemod:
+                - scratchPad: !<value> 0x40000000
+                - maxHoldReset: !<value> 0x0
+                - setQ: !<value> 0x0000
+                - setI: !<value> 0x3fff
+            - LlrfUpconvert:
+                - scratchPad: !<value> 0x00000000
+                - dacMax: !<value> 0x7fff
+                - dacMin: !<value> 0xffffffffffff8000
+                - dacOffset: !<value> 0x0000
+                - basebandQSet: !<value> 0x0000
+                - invertCorrection: !<value> 0x0
+                - basebandISet: !<value> 0x0000
+                - referenceChannel1: !<value> 0x0
+                - referenceChannel0: !<value> 0x0
+                - loSelect: !<value> 0x0
+                - modeSelect: !<value> 0x0
+                - rfEnable: !<value> 0x0
+        - AmcMrLlrfDownConvert:
+            - Lmk04828:
+                - EnableSysRef: !<value> 0x3
+                - EnableSync: !<value> 0xff
+                - SyncBit: !<value> 0x0
+                - LmkReg_0x016E: !<value> 0x13
+                - LmkReg_0x016D: !<value> 0x00
+                - LmkReg_0x016C: !<value> 0x00
+                - LmkReg_0x016B: !<value> 0x00
+                - LmkReg_0x016A: !<value> 0x20
+                - LmkReg_0x0169: !<value> 0x59
+                - LmkReg_0x0168: !<value> 0x0c
+                - LmkReg_0x0167: !<value> 0x00
+                - LmkReg_0x0166: !<value> 0x00
+                - LmkReg_0x017D: !<value> 0x33
+                - LmkReg_0x017C: !<value> 0x15
+                - LmkReg_0x0174: !<value> 0x00
+                - LmkReg_0x0173: !<value> 0x00
+                - LmkReg_0x0172: !<value> 0x00
+                - LmkReg_0x0171: !<value> 0x0a
+                - LmkReg_0x0165: !<value> 0x0c
+                - LmkReg_0x0164: !<value> 0x00
+                - LmkReg_0x0163: !<value> 0x00
+                - LmkReg_0x0162: !<value> 0x44
+                - LmkReg_0x0161: !<value> 0x01
+                - LmkReg_0x0160: !<value> 0x00
+                - LmkReg_0x015F: !<value> 0x0b
+                - LmkReg_0x015E: !<value> 0x00
+                - LmkReg_0x015D: !<value> 0x00
+                - LmkReg_0x015C: !<value> 0x20
+                - LmkReg_0x015B: !<value> 0xd4
+                - LmkReg_0x015A: !<value> 0x00
+                - LmkReg_0x0159: !<value> 0x06
+                - LmkReg_0x0158: !<value> 0x96
+                - LmkReg_0x0157: !<value> 0x00
+                - LmkReg_0x0156: !<value> 0x7d
+                - LmkReg_0x0155: !<value> 0x00
+                - LmkReg_0x0154: !<value> 0x78
+                - LmkReg_0x0153: !<value> 0x00
+                - LmkReg_0x0152: !<value> 0x00
+                - LmkReg_0x0151: !<value> 0x02
+                - LmkReg_0x0150: !<value> 0x03
+                - LmkReg_0x014F: !<value> 0x7f
+                - LmkReg_0x014E: !<value> 0x00
+                - LmkReg_0x014D: !<value> 0x00
+                - LmkReg_0x014C: !<value> 0x00
+                - LmkReg_0x014B: !<value> 0x16
+                - LmkReg_0x014A: !<value> 0x02
+                - LmkReg_0x0149: !<value> 0x02
+                - LmkReg_0x0148: !<value> 0x02
+                - LmkReg_0x0147: !<value> 0x40
+                - LmkReg_0x0146: !<value> 0x18
+                - LmkReg_0x0145: !<value> 0x7f
+                - LmkReg_0x0144: !<value> 0xff
+                - LmkReg_0x0143: !<value> 0x51
+                - LmkReg_0x0142: !<value> 0x00
+                - LmkReg_0x0141: !<value> 0x00
+                - LmkReg_0x0140: !<value> 0x00
+                - LmkReg_0x013F: !<value> 0x00
+                - LmkReg_0x013E: !<value> 0x03
+                - LmkReg_0x013D: !<value> 0x08
+                - LmkReg_0x013C: !<value> 0x00
+                - LmkReg_0x013B: !<value> 0x00
+                - LmkReg_0x013A: !<value> 0x01
+                - LmkReg_0x0139: !<value> 0x03
+                - LmkReg_0x0138: !<value> 0x40
+                - LmkReg_0x0137: !<value> 0x11
+                - LmkReg_0x0136: !<value> 0x70
+                - LmkReg_0x0135: !<value> 0x00
+                - LmkReg_0x0134: !<value> 0x00
+                - LmkReg_0x0133: !<value> 0x00
+                - LmkReg_0x0131: !<value> 0x55
+                - LmkReg_0x0130: !<value> 0x02
+                - LmkReg_0x012F: !<value> 0x11
+                - LmkReg_0x012E: !<value> 0x70
+                - LmkReg_0x012D: !<value> 0x00
+                - LmkReg_0x012C: !<value> 0x20
+                - LmkReg_0x012B: !<value> 0x00
+                - LmkReg_0x0129: !<value> 0x55
+                - LmkReg_0x0128: !<value> 0x02
+                - LmkReg_0x0127: !<value> 0x11
+                - LmkReg_0x0126: !<value> 0x70
+                - LmkReg_0x0125: !<value> 0x00
+                - LmkReg_0x0124: !<value> 0x20
+                - LmkReg_0x0123: !<value> 0x00
+                - LmkReg_0x0121: !<value> 0x55
+                - LmkReg_0x0120: !<value> 0x02
+                - LmkReg_0x011F: !<value> 0x11
+                - LmkReg_0x011E: !<value> 0x70
+                - LmkReg_0x011D: !<value> 0x00
+                - LmkReg_0x011C: !<value> 0x20
+                - LmkReg_0x011B: !<value> 0x02
+                - LmkReg_0x0119: !<value> 0x55
+                - LmkReg_0x0118: !<value> 0x01
+                - LmkReg_0x0117: !<value> 0x11
+                - LmkReg_0x0116: !<value> 0x70
+                - LmkReg_0x0115: !<value> 0x00
+                - LmkReg_0x0114: !<value> 0x20
+                - LmkReg_0x0113: !<value> 0x02
+                - LmkReg_0x0111: !<value> 0x55
+                - LmkReg_0x0110: !<value> 0x01
+                - LmkReg_0x010F: !<value> 0x11
+                - LmkReg_0x010E: !<value> 0x70
+                - LmkReg_0x010D: !<value> 0x00
+                - LmkReg_0x010C: !<value> 0x20
+                - LmkReg_0x010B: !<value> 0x02
+                - LmkReg_0x0109: !<value> 0x55
+                - LmkReg_0x0108: !<value> 0x01
+                - LmkReg_0x0107: !<value> 0x11
+                - LmkReg_0x0106: !<value> 0x70
+                - LmkReg_0x0105: !<value> 0x00
+                - LmkReg_0x0104: !<value> 0x20
+                - LmkReg_0x0103: !<value> 0x02
+                - LmkReg_0x0101: !<value> 0x55
+                - LmkReg_0x0100: !<value> 0x01
+                - LmkReg_0x0002: !<value> 0x00
+                - LmkReg_0x0000: !<value> 0x00
+            - Adt7420:
+                - THyst: !<value>
+                    - 0x08
+                    - 0x09
+                    - 0x09
+                    - 0x07
+                - TCritLSByte: !<value>
+                    - 0x18
+                    - 0x19
+                    - 0x19
+                    - 0x17
+                - TCritMSByte: !<value>
+                    - 0x18
+                    - 0x19
+                    - 0x19
+                    - 0x17
+                - TLowLSByte: !<value>
+                    - 0x18
+                    - 0x19
+                    - 0x19
+                    - 0x17
+                - TLowMSByte: !<value>
+                    - 0x18
+                    - 0x19
+                    - 0x19
+                    - 0x17
+                - THighLSByte: !<value>
+                    - 0x18
+                    - 0x19
+                    - 0x19
+                    - 0x17
+                - Config: !<value>
+                    - 0x18
+                    - 0x19
+                    - 0x19
+                    - 0x17
+                - THighMSByte: !<value>
+                    - 0x18
+                    - 0x19
+                    - 0x19
+                    - 0x17
+            - Adc16Dx370:
+                - AdcReg_0x0070: !<value> 0x22
+                - AdcReg_0x0063: !<value> 0x00
+                - AdcReg_0x0062: !<value> 0x01
+                - AdcReg_0x0061: !<value> 0x00
+                - AdcReg_0x0060: !<value> 0xfd
+                - AdcReg_0x0047: !<value> 0x33
+                - AdcReg_0x003D: !<value> 0x00
+                - AdcReg_0x003C: !<value> 0x00
+                - AdcReg_0x003B: !<value> 0x00
+                - AdcReg_0x0015: !<value> 0x00
+                - AdcReg_0x0014: !<value> 0x00
+                - AdcReg_0x0019: !<value> 0x00
+                - AdcReg_0x0013: !<value> 0x40
+                - AdcReg_0x0012: !<value> 0x85
+                - AdcReg_0x0011: !<value> 0x00
+                - AdcReg_0x0010: !<value> 0x01
+                - AdcReg_0x000F: !<value> 0x00
+                - AdcReg_0x000E: !<value> 0x00
+                - AdcReg_0x000D: !<value> 0x04
+                - AdcReg_0x000C: !<value> 0x51
+                - AdcReg_0x0006: !<value> 0x01
+                - AdcReg_0x0005: !<value> 0x00
+                - AdcReg_0x0004: !<value> 0x00
+                - AdcReg_0x0003: !<value> 0x03
+                - AdcReg_0x0002: !<value> 0x00
+                - AdcReg_0x0000: !<value> 0x3c
+            - DacAd5541:
+                - SetValue: !<value> 0x0000
+            - AttHMC624:
+                - SetValue: !<value>
+                    - 0x003c
+                    - 0x003c
+                    - 0x003f
+                    - 0x0036
+                    - 0x003f
+                    - 0x003f
+            - DacAD5541Mux:
+                - SckHalfPeriod: !<value> 0x0005
+                - SelectDspCore: !<value> 0x1
+        - AmcMrLlrfGen2UpConvert:
+            - Dac38J84:
+                - EnableTx: !<value> 0x1
+                - DacReg: !<value>
+                    - 0x0218
+                    - 0x0003
+                    - 0x2082 #zero JESD when link not estb not 2s 4 wire
+                    - 0xA300
+                    - 0xF3F3
+                    - 0xFF07
+                    - 0xFFFF # mask everything
+                    - 0x3800
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0400
+                    - 0x0400
+                    - 0x0400
+                    - 0x0400
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0xf3cf  #configure NCO freq if needed
+                    - 0xcf3c  #configure NCO freq if needed
+                    - 0xcf3c  #configure NCO freq if needed
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0023
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x9999 # value from Larry
+                    - 0x9980 # value from Larry
+                    - 0x8008 # value from Larry
+                    - 0x0000
+                    - 0x1b1b # value from Larry
+                    - 0x01ff
+                    - 0x0020
+                    - 0x0000 # intp = 1 so same as DAC clk
+                    - 0x0000
+                    - 0x0000
+                    - 0x003f
+                    - 0xffff
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0001
+                    - 0xffff
+                    - 0x0004
+                    - 0x0000
+                    - 0x1000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000  #cryo has this set to 0x1800
+                    - 0x0250  # Cryo is 0x0028 eval board is 0x228
+                    - 0x0088  # Fully adaptive equalizer, boost on
+                    - 0x0128  # JESD termination setting and rate. enable loss of signal detection
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x1882
+                    - 0x01c8
+                    - 0x3143
+                    - 0x0000 # 4 seems right, sends JESD0 to link 0 and JESD1 to Link1
+                    - 0x821 # Only use RX3
+                    - 0x0801
+                    - 0x0901 #using 2 lanes of JESD
+                    - 0x0100
+                    - 0x0f0f  # Enable scrambler nothigh density mode
+                    - 0x1c61
+                    - 0x0000
+                    - 0x00DC  # sync_request_ena_link0
+                    - 0x00FF  # error_ena_link0
+                    - 0x0000
+                    - 0x00FC  # sync_request_ena_link1
+                    - 0x00FF  # error_ena_link1
+                    - 0x0000
+                    - 0x00ff
+                    - 0x00ff
+                    - 0x0000
+                    - 0x00ff
+                    - 0x00ff
+                    - 0x1133  # Skip two SYSREF pulses then use all pulses.
+                    - 0x0000
+                    - 0x0000
+                    - 0x3310  #Send RX3 to both dacs
+                    - 0x5764
+                    - 0x0211
+                    - 0x0000
+                    - 0x0000
+                    - 0x0 # write to clear alarms
+                    - 0x0 # write to clear alarms0
+                    - 0x0 # write to clear alarms0
+                    - 0x0 # write to clear alarms0
+                    - 0x0 # write to clear alarms0
+                    - 0x0 # write to clear alarms0
+                    - 0x0 # write to clear alarms0
+                    - 0x0 # write to clear alarms0
+                    - 0x0 # write to clear alarms0
+                    - 0x0 # write to clear alarms0
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+                    - 0x0000
+            - Lmk04828:
+                - EnableSysRef: !<value> 0x3
+                - EnableSync: !<value> 0xff
+                - SyncBit: !<value> 0x0
+                - LmkReg_0x016B: !<value> 0x00
+                - LmkReg_0x016C: !<value> 0x00
+                - LmkReg_0x016D: !<value> 0x00
+                - LmkReg_0x016E: !<value> 0x13
+                - LmkReg_0x0173: !<value> 0x00
+                - LmkReg_0x0174: !<value> 0x00
+                - LmkReg_0x017C: !<value> 0x15
+                - LmkReg_0x017D: !<value> 0x33
+                - LmkReg_0x016A: !<value> 0x20
+                - LmkReg_0x0169: !<value> 0x59
+                - LmkReg_0x0168: !<value> 0x0c
+                - LmkReg_0x0167: !<value> 0x00
+                - LmkReg_0x0166: !<value> 0x00
+                - LmkReg_0x0165: !<value> 0x0c
+                - LmkReg_0x0164: !<value> 0x00
+                - LmkReg_0x0163: !<value> 0x00
+                - LmkReg_0x0162: !<value> 0x44
+                - LmkReg_0x0161: !<value> 0x01
+                - LmkReg_0x0160: !<value> 0x00
+                - LmkReg_0x015F: !<value> 0x0b
+                - LmkReg_0x015E: !<value> 0x00
+                - LmkReg_0x015D: !<value> 0x00
+                - LmkReg_0x015C: !<value> 0x20
+                - LmkReg_0x015B: !<value> 0xd4
+                - LmkReg_0x015A: !<value> 0x00
+                - LmkReg_0x0159: !<value> 0x06
+                - LmkReg_0x0158: !<value> 0x96
+                - LmkReg_0x0157: !<value> 0x00
+                - LmkReg_0x0156: !<value> 0x7d
+                - LmkReg_0x0155: !<value> 0x00
+                - LmkReg_0x0154: !<value> 0x78
+                - LmkReg_0x0153: !<value> 0x00
+                - LmkReg_0x0152: !<value> 0x00
+                - LmkReg_0x0151: !<value> 0x02
+                - LmkReg_0x0150: !<value> 0x03
+                - LmkReg_0x014F: !<value> 0x7f
+                - LmkReg_0x014E: !<value> 0x00
+                - LmkReg_0x014D: !<value> 0x00
+                - LmkReg_0x014C: !<value> 0x00
+                - LmkReg_0x014B: !<value> 0x16
+                - LmkReg_0x014A: !<value> 0x02
+                - LmkReg_0x0149: !<value> 0x02
+                - LmkReg_0x0148: !<value> 0x02
+                - LmkReg_0x0147: !<value> 0x40
+                - LmkReg_0x0146: !<value> 0x18
+                - LmkReg_0x0145: !<value> 0x7f
+                - LmkReg_0x0144: !<value> 0xff
+                - LmkReg_0x0143: !<value> 0x51
+                - LmkReg_0x0142: !<value> 0x00
+                - LmkReg_0x0141: !<value> 0x00
+                - LmkReg_0x0140: !<value> 0x00
+                - LmkReg_0x013F: !<value> 0x00
+                - LmkReg_0x013E: !<value> 0x03
+                - LmkReg_0x013D: !<value> 0x08
+                - LmkReg_0x013C: !<value> 0x00
+                - LmkReg_0x013B: !<value> 0x00
+                - LmkReg_0x013A: !<value> 0x01
+                - LmkReg_0x0139: !<value> 0x03
+                - LmkReg_0x0138: !<value> 0x40
+                - LmkReg_0x0137: !<value> 0x11
+                - LmkReg_0x0136: !<value> 0x70
+                - LmkReg_0x0135: !<value> 0x00
+                - LmkReg_0x0134: !<value> 0x00
+                - LmkReg_0x0133: !<value> 0x00
+                - LmkReg_0x0131: !<value> 0x55
+                - LmkReg_0x0130: !<value> 0x02
+                - LmkReg_0x012F: !<value> 0x11
+                - LmkReg_0x012E: !<value> 0x70
+                - LmkReg_0x012D: !<value> 0x00
+                - LmkReg_0x012C: !<value> 0x20
+                - LmkReg_0x012B: !<value> 0x00
+                - LmkReg_0x0129: !<value> 0x55
+                - LmkReg_0x0128: !<value> 0x02
+                - LmkReg_0x0126: !<value> 0x70
+                - LmkReg_0x0125: !<value> 0x00
+                - LmkReg_0x0124: !<value> 0x20
+                - LmkReg_0x0127: !<value> 0x11
+                - LmkReg_0x0123: !<value> 0x00
+                - LmkReg_0x0121: !<value> 0x55
+                - LmkReg_0x0120: !<value> 0x02
+                - LmkReg_0x011F: !<value> 0x11
+                - LmkReg_0x011E: !<value> 0x70
+                - LmkReg_0x011D: !<value> 0x00
+                - LmkReg_0x011C: !<value> 0x20
+                - LmkReg_0x011B: !<value> 0x02
+                - LmkReg_0x0119: !<value> 0x55
+                - LmkReg_0x0118: !<value> 0x01
+                - LmkReg_0x0117: !<value> 0x11
+                - LmkReg_0x0115: !<value> 0x00
+                - LmkReg_0x0116: !<value> 0x70
+                - LmkReg_0x0114: !<value> 0x20
+                - LmkReg_0x0113: !<value> 0x02
+                - LmkReg_0x0111: !<value> 0x55
+                - LmkReg_0x0110: !<value> 0x01
+                - LmkReg_0x010F: !<value> 0x11
+                - LmkReg_0x010E: !<value> 0x70
+                - LmkReg_0x010D: !<value> 0x00
+                - LmkReg_0x010C: !<value> 0x20
+                - LmkReg_0x010B: !<value> 0x02
+                - LmkReg_0x0109: !<value> 0x55
+                - LmkReg_0x0108: !<value> 0x01
+                - LmkReg_0x0107: !<value> 0x11
+                - LmkReg_0x0106: !<value> 0x70
+                - LmkReg_0x0105: !<value> 0x00
+                - LmkReg_0x0104: !<value> 0x20
+                - LmkReg_0x0103: !<value> 0x02
+                - LmkReg_0x0101: !<value> 0x55
+                - LmkReg_0x0100: !<value> 0x01
+            - Adt7420:
+                - THyst: !<value> 0x05
+                - TCritLSByte: !<value> 0x80
+                - TCritMSByte: !<value> 0x49
+                - TLowLSByte: !<value> 0x00
+                - TLowMSByte: !<value> 0x05
+                - THighLSByte: !<value> 0x00
+                - THighMSByte: !<value> 0x20
+                - Config: !<value> 0x00
+            - AttHMC624:
+                - SetValue: !<value> 0x003f
+            - Adc16Dx370:
+                - AdcReg_0x0070: !<value> 0x22
+                - AdcReg_0x0063: !<value> 0x00
+                - AdcReg_0x0062: !<value> 0x01
+                - AdcReg_0x0061: !<value> 0x00
+                - AdcReg_0x0060: !<value> 0xfd
+                - AdcReg_0x0047: !<value> 0x33
+                - AdcReg_0x003D: !<value> 0x00
+                - AdcReg_0x003C: !<value> 0x00
+                - AdcReg_0x003B: !<value> 0x00
+                - AdcReg_0x0019: !<value> 0x00
+                - AdcReg_0x0015: !<value> 0x00
+                - AdcReg_0x0014: !<value> 0x00
+                - AdcReg_0x0013: !<value> 0x40
+                - AdcReg_0x0012: !<value> 0x85
+                - AdcReg_0x0011: !<value> 0x00
+                - AdcReg_0x0010: !<value> 0x01
+                - AdcReg_0x000F: !<value> 0x00
+                - AdcReg_0x000E: !<value> 0x00
+                - AdcReg_0x000D: !<value> 0x04
+                - AdcReg_0x000C: !<value> 0x51
+                - AdcReg_0x0006: !<value> 0x01
+                - AdcReg_0x0005: !<value> 0x00
+                - AdcReg_0x0004: !<value> 0x00
+                - AdcReg_0x0003: !<value> 0x03
+                - AdcReg_0x0002: !<value> 0x00
+                - AdcReg_0x0000: !<value> 0x3c
+    - AppTopJesd:
+        - JesdRx:
+            - ThresholdHigh: !<value>
+                - 0xa000
+                - 0xa000
+                - 0xa000
+                - 0xa000
+                - 0xa000
+                - 0xa000
+                - 0x0000
+                - 0x0000
+                - 0xa000
+                - 0xa000
+                - 0xa000
+                - 0xa000
+                - 0xa000
+                - 0xa000
+                - 0x0000
+                - 0x0000
+            - ThresholdLow: !<value>
+                - 0x5000
+                - 0x5000
+                - 0x5000
+                - 0x5000
+                - 0x5000
+                - 0x5000
+                - 0x0000
+                - 0x0000
+                - 0x5000
+                - 0x5000
+                - 0x5000
+                - 0x5000
+                - 0x5000
+                - 0x5000
+                - 0x0000
+                - 0x0000
+            - PowerDown: !<value> 0x00
+            - LinkErrMask: !<value> 0x3f
+            - InvertAdcData: !<value> 0x00
+            - ScrambleEnable: !<value> Enabled
+            - InvertSync: !<value> Inverted
+            - ResetGTs: !<value> 0x0
+            - ClearErrors: !<value> 0x0
+            - ReplaceEnable: !<value> Enabled
+            - SubClass: !<value> 0x1
+            - SysrefDelay: !<value> 0x00
+            - Enable: !<value> 0x3f
+    - DaqMuxV2:
+        - DecimationAveraging: !<value>
+            - Enabled
+            - Enabled
+            - Enabled
+            - Enabled
+            - Disabled
+            - Disabled
+            - Disabled
+            - Disabled
+        - FormatSign: !<value> Unsigned
+        - FormatDataWidth: !<value> D32-bit
+        - FormatSignWidth: !<value> 0x00
+        - InputMuxSel: !<value>
+            - Ch1
+            - Test
+            - Test
+            - Test
+            - Test
+            - Test
+            - Test
+            - Test
+        - DataBufferSize: !<value> 0x000007d0
+        - DecimationRateDiv: !<value> 0x0000
+        - FreezeSw: !<value> 0x0
+        - FreezeHwMask: !<value>
+            - Disabled
+            - Enabled
+        - PacketHeaderEn: !<value> Enabled
+        - DaqMode: !<value> TriggeredMode
+        - TriggerClearStatus: !<value> 0x0
+        - TriggerHwArm: !<value> 0x0
+        - TriggerHwAutoRearm: !<value> Enabled
+        - TriggerCascMask: !<value>
+            - Enabled
+            - Disabled
+        - TriggerSw: !<value> 0x0
+


### PR DESCRIPTION
I used the defaults used by the `Llrf` target as a base. I remove the `AmcMrLlrfUpConvert` section, and added a new section `AmcMrLlrfGen2UpConvert` where I copied the values from the defaults file used with Rogue.