### PR TITLE
Remove workaraound as the new firmware includes this fix

### DIFF
--- a/software/python/gen2_up_converter/init.py
+++ b/software/python/gen2_up_converter/init.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
         sysref_period_min = poll_and_read_pv('{}:AT:ATJ1:JR:SysRefPeriodmin:Rd'.format(epics_prefix))
         sysref_period_max = poll_and_read_pv('{}:AT:ATJ1:JR:SysRefPeriodmax:Rd'.format(epics_prefix))
 
-        if sysref_period_min != (sysref_period_max - 1):
+        if sysref_period_min != sysref_period_max:
             print('Link not locked: SysRefPeriodmin = {}, SysRefPeriodmax = {}'.format(sysref_period_min, sysref_period_max))
             link_locked = False
 


### PR DESCRIPTION
This was a workaround to an issue present in the initial FW version. Now that the FW was updated with the fix, we need to remove this workaround.